### PR TITLE
Release v1.2.1

### DIFF
--- a/handler/build.gradle
+++ b/handler/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.jeyong'
-version = '1.2.0'
+version = '1.2.1'
 
 ext {
     artifactName = 'k8s-sigterm-handler'

--- a/handler/src/main/java/io/jeyong/handler/ApplicationTerminator.java
+++ b/handler/src/main/java/io/jeyong/handler/ApplicationTerminator.java
@@ -4,8 +4,19 @@ import sun.misc.SignalHandler;
 
 public abstract class ApplicationTerminator {
 
+    private final String terminationMessagePath;
+    private final String terminationMessage;
+
+    protected ApplicationTerminator(final String terminationMessagePath, final String terminationMessage) {
+        this.terminationMessagePath = terminationMessagePath;
+        this.terminationMessage = terminationMessage;
+    }
+
     public SignalHandler handleTermination() {
-        return signal -> System.exit(getExitCode());
+        return signal -> {
+            FileUtils.writeToFile(terminationMessagePath, terminationMessage);
+            System.exit(getExitCode());
+        };
     }
 
     protected abstract int getExitCode();

--- a/handler/src/main/java/io/jeyong/handler/FileUtils.java
+++ b/handler/src/main/java/io/jeyong/handler/FileUtils.java
@@ -1,0 +1,38 @@
+package io.jeyong.handler;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
+
+    private FileUtils() {
+    }
+
+    public static void writeToFile(final String filePath, final String message) {
+        if (filePath == null || filePath.isBlank()) {
+            return;
+        }
+
+        final File file = new File(filePath);
+        try {
+            createParentDirectories(file);
+            try (FileWriter writer = new FileWriter(file)) {
+                writer.write(message);
+            }
+        } catch (IOException e) {
+            logger.error("Failed to write to file {}: {}", filePath, e.getMessage());
+        }
+    }
+
+    private static void createParentDirectories(final File file) throws IOException {
+        final File parentDir = file.getParentFile();
+        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+            throw new IOException("Failed to create parent directories for " + file.getAbsolutePath());
+        }
+    }
+}

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerConfiguration.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerConfiguration.java
@@ -26,7 +26,8 @@ public class SigtermHandlerConfiguration {
 
     @Bean
     public ApplicationTerminator applicationTerminator(final ApplicationContext applicationContext) {
-        return new SpringContextTerminator(applicationContext, sigtermHandlerProperties.getExitCode());
+        return new SpringContextTerminator(applicationContext, sigtermHandlerProperties.getExitCode(),
+                sigtermHandlerProperties.getTerminationMessagePath(), sigtermHandlerProperties.getTerminationMessage());
     }
 
     @Bean

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerConfiguration.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnProperty(
-        prefix = "kubernetes.handler",
+        prefix = "kubernetes.sigterm-handler",
         name = "enabled",
         havingValue = "true",
         matchIfMissing = true

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -7,20 +7,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Kubernetes SIGTERM handling.
  *
  * <p>
- * Allows customization of the SIGTERM handler's behavior, including whether it is enabled and the exit code to use
- * during graceful termination.
+ * Allows customization of the Sigterm Handler's behavior,
+ * including whether it is enabled and the exit code to use during graceful termination.
  * </p>
  *
  * <ul>
- *     <li><b>kubernetes.handler.enabled:</b> Set whether the handler is enabled or disabled (default: true).</li>
- *     <li><b>kubernetes.handler.exit-code:</b> Set the exit code for graceful application termination (default: 0).</li>
+ *     <li><b>kubernetes.sigterm-handler.enabled:</b> Set whether the handler is enabled or disabled (default: true).</li>
+ *     <li><b>kubernetes.sigterm-handler.exit-code:</b> Set the exit code for graceful application termination (default: 0).</li>
  * </ul>
  *
  * <pre>
  * Example configuration (YAML):
  * {@code
  * kubernetes:
- *   handler:
+ *   sigterm-handler:
  *     enabled: true
  *     exit-code: 1
  * }
@@ -29,13 +29,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * <pre>
  * Example configuration (Properties):
  * {@code
- * kubernetes.handler.enabled=true
- * kubernetes.handler.exit-code=1
+ * kubernetes.sigterm-handler.enabled=true
+ * kubernetes.sigterm-handler.exit-code=1
  * }
  * </pre>
  *
  * <p>
- * By default, the handler is enabled, and the application terminates with an exit code of 0,
+ * By default, the Sigterm Handler is enabled, and the application terminates with an exit code of 0,
  * marking the Kubernetes Pod as "Completed."
  * </p>
  *
@@ -44,7 +44,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @see SigtermHandlerConfiguration
  */
 // @formatter:on
-@ConfigurationProperties(prefix = "kubernetes.handler")
+@ConfigurationProperties(prefix = "kubernetes.sigterm-handler")
 public class SigtermHandlerProperties {
 
     private boolean enabled = true;

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -1,7 +1,9 @@
 package io.jeyong.handler;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 // @formatter:off
-import org.springframework.boot.context.properties.ConfigurationProperties; /**
+/**
  * Configuration properties for Kubernetes SIGTERM handling.
  *
  * <p>
@@ -11,7 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties; /**
  *
  * <ul>
  *     <li><b>kubernetes.handler.enabled:</b> Set whether the handler is enabled or disabled (default: true).</li>
- *     <li><b>kubernetes.handler.exit-code:</b> Sets the exit code for graceful application termination (default: 0).</li>
+ *     <li><b>kubernetes.handler.exit-code:</b> Set the exit code for graceful application termination (default: 0).</li>
  * </ul>
  *
  * <pre>
@@ -46,7 +48,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties; /**
 public class SigtermHandlerProperties {
 
     private boolean enabled = true;
-
     private int exitCode = 0;
 
     public boolean isEnabled() {

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -14,7 +14,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * <ul>
  *     <li><b>kubernetes.sigterm-handler.enabled:</b> Set whether the handler is enabled or disabled. (default: true)</li>
  *     <li><b>kubernetes.sigterm-handler.exit-code:</b> Set the exit code for graceful application termination. (default: 0)</li>
- *     <li><b>kubernetes.sigterm-handler.termination-message-path:</b> Set the file path where the termination message should be written. (optional)</li>
+ *     <li><b>kubernetes.sigterm-handler.termination-message-path:</b> Set the file path where the termination message should be written. (default: not set)</li>
  *     <li><b>kubernetes.sigterm-handler.termination-message:</b> Set the content of the termination message written to the specified path. (default: SIGTERM signal received. Application has been terminated successfully.)</li>
  * </ul>
  *

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -49,6 +49,8 @@ public class SigtermHandlerProperties {
 
     private boolean enabled = true;
     private int exitCode = 0;
+    private String terminationMessagePath;
+    private String terminationMessage = "SIGTERM signal received. Application has been terminated successfully.";
 
     public boolean isEnabled() {
         return enabled;
@@ -64,5 +66,21 @@ public class SigtermHandlerProperties {
 
     public void setExitCode(final int exitCode) {
         this.exitCode = exitCode;
+    }
+
+    public String getTerminationMessagePath() {
+        return terminationMessagePath;
+    }
+
+    public void setTerminationMessagePath(final String terminationMessagePath) {
+        this.terminationMessagePath = terminationMessagePath;
+    }
+
+    public String getTerminationMessage() {
+        return terminationMessage;
+    }
+
+    public void setTerminationMessage(final String terminationMessage) {
+        this.terminationMessage = terminationMessage;
     }
 }

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -7,13 +7,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Kubernetes SIGTERM handling.
  *
  * <p>
- * Allows customization of the Sigterm Handler's behavior,
- * including whether it is enabled and the exit code to use during graceful termination.
+ * Allows customization of the Sigterm Handler's behavior, including whether it is enabled,
+ * the exit code to use during graceful termination, and optional termination message settings.
  * </p>
  *
  * <ul>
- *     <li><b>kubernetes.sigterm-handler.enabled:</b> Set whether the handler is enabled or disabled (default: true).</li>
- *     <li><b>kubernetes.sigterm-handler.exit-code:</b> Set the exit code for graceful application termination (default: 0).</li>
+ *     <li><b>kubernetes.sigterm-handler.enabled:</b> Set whether the handler is enabled or disabled. (default: true)</li>
+ *     <li><b>kubernetes.sigterm-handler.exit-code:</b> Set the exit code for graceful application termination. (default: 0)</li>
+ *     <li><b>kubernetes.sigterm-handler.termination-message-path:</b> Set the file path where the termination message should be written. (optional)</li>
+ *     <li><b>kubernetes.sigterm-handler.termination-message:</b> Set the content of the termination message written to the specified path. (default: SIGTERM signal received. Application has been terminated successfully.)</li>
  * </ul>
  *
  * <pre>
@@ -22,7 +24,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * kubernetes:
  *   sigterm-handler:
  *     enabled: true
- *     exit-code: 1
+ *     exit-code: 0
+ *     termination-message-path: /dev/termination-log
+ *     termination-message: SIGTERM signal received...
  * }
  * </pre>
  *
@@ -30,17 +34,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Example configuration (Properties):
  * {@code
  * kubernetes.sigterm-handler.enabled=true
- * kubernetes.sigterm-handler.exit-code=1
+ * kubernetes.sigterm-handler.exit-code=0
+ * kubernetes.sigterm-handler.termination-message-path=/dev/termination-log
+ * kubernetes.sigterm-handler.termination-message=SIGTERM signal received...
  * }
  * </pre>
  *
  * <p>
- * By default, the Sigterm Handler is enabled, and the application terminates with an exit code of 0,
- * marking the Kubernetes Pod as "Completed."
+ * The Sigterm Handler is primarily designed for Kubernetes
+ * but can also be utilized in Docker or other environments requiring signal handling functionality.
  * </p>
  *
  * @author jeyong
- * @since 1.0
+ * @since 1.2
  * @see SigtermHandlerConfiguration
  */
 // @formatter:on

--- a/handler/src/main/java/io/jeyong/handler/SpringContextTerminator.java
+++ b/handler/src/main/java/io/jeyong/handler/SpringContextTerminator.java
@@ -8,7 +8,9 @@ public class SpringContextTerminator extends ApplicationTerminator {
     private final ApplicationContext applicationContext;
     private final int exitCode;
 
-    public SpringContextTerminator(final ApplicationContext applicationContext, final int exitCode) {
+    public SpringContextTerminator(final ApplicationContext applicationContext, final int exitCode,
+                                   final String terminationMessagePath, final String terminationMessage) {
+        super(terminationMessagePath, terminationMessage);
         this.applicationContext = applicationContext;
         this.exitCode = exitCode;
     }

--- a/test/src/test/java/io/jeyong/test/integration/SigtermHandlerTest.java
+++ b/test/src/test/java/io/jeyong/test/integration/SigtermHandlerTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,15 +23,26 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 @DisplayName("SigtermHandler Integration Test")
 public class SigtermHandlerTest {
 
+    private static final int EXPECTED_EXIT_CODE = 10;
+    private static final String TERMINATION_MESSAGE_PATH = "/app/termination-message.message";
+    private static final String TERMINATION_MESSAGE = "Test termination message";
+
+    private static Path codeDir;
     private static ImageFromDockerfile dockerImage;
 
     @BeforeAll
-    static void setUp() {
-        dockerImage = buildImage();
+    static void setUp() throws Exception {
+        codeDir = createCodeDirectory();
+        dockerImage = buildImage(codeDir);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        FileUtils.deleteDirectory(codeDir.toFile());
     }
 
     @Test
-    @DisplayName("Container should exit with code 0 on SIGTERM")
+    @DisplayName("Container should exit with expected code on SIGTERM")
     void testExitCode() throws Exception {
         // given
         GenericContainer<?> container = new GenericContainer<>(dockerImage)
@@ -42,7 +54,7 @@ public class SigtermHandlerTest {
 
         // then
         Long exitCode = container.getCurrentContainerInfo().getState().getExitCodeLong();
-        assertThat(exitCode).isEqualTo(0);
+        assertThat(exitCode).isEqualTo(EXPECTED_EXIT_CODE);
     }
 
     @Test
@@ -65,10 +77,52 @@ public class SigtermHandlerTest {
         });
     }
 
-    private static ImageFromDockerfile buildImage() {
-        Path tempDir = createTempDirectory();
+    @Test
+    @DisplayName("Check termination message file inside container")
+    void testTerminationMessageFile() throws Exception {
+        // given
+        GenericContainer<?> container = new GenericContainer<>(dockerImage)
+                .waitingFor(forLogMessage(".*Started TestApplication.*\\n", 1));
+        container.start();
+
+        // when
+        sendSigtermToContainer(container);
+
+        // then
+        String fileContent = container.copyFileFromContainer(
+                TERMINATION_MESSAGE_PATH,
+                content -> new String(content.readAllBytes())
+        );
+        assertThat(fileContent).isEqualTo(TERMINATION_MESSAGE);
+    }
+
+    private static Path createCodeDirectory() throws Exception {
+        Path codeDir = Files.createTempDirectory("docker-context");
+        copyFile("../gradlew", codeDir.resolve("gradlew"));
+        copyDirectory("../gradle", codeDir.resolve("gradle"));
+        copyFile("../settings.gradle", codeDir.resolve("settings.gradle"));
+        copyDirectory("../handler", codeDir.resolve("handler"));
+        copyDirectory("../test", codeDir.resolve("test"));
+        createApplicationYaml(codeDir.resolve("test/src/main/resources"));
+        return codeDir;
+    }
+
+    private static void createApplicationYaml(Path resourcesDir) throws Exception {
+        Files.createDirectories(resourcesDir);
+        Path applicationYaml = resourcesDir.resolve("application.yml");
+        String yamlContent = String.format("""
+                kubernetes:
+                  sigterm-handler:
+                    exit-code: %d
+                    termination-message-path: %s
+                    termination-message: %s
+                """, EXPECTED_EXIT_CODE, TERMINATION_MESSAGE_PATH, TERMINATION_MESSAGE);
+        Files.writeString(applicationYaml, yamlContent);
+    }
+
+    private static ImageFromDockerfile buildImage(Path sourceCodeDir) {
         return new ImageFromDockerfile()
-                .withFileFromPath(".", tempDir)
+                .withFileFromPath(".", sourceCodeDir)
                 .withDockerfileFromBuilder(builder -> {
                     builder.from("eclipse-temurin:17")
                             .workDir("/app")
@@ -82,20 +136,6 @@ public class SigtermHandlerTest {
                             .cmd("java", "-jar", "/app/test/build/libs/test-0.0.1-SNAPSHOT.jar")
                             .build();
                 });
-    }
-
-    private static Path createTempDirectory() {
-        try {
-            Path tempDir = Files.createTempDirectory("docker-context");
-            copyFile("../gradlew", tempDir.resolve("gradlew"));
-            copyDirectory("../gradle", tempDir.resolve("gradle"));
-            copyFile("../settings.gradle", tempDir.resolve("settings.gradle"));
-            copyDirectory("../handler", tempDir.resolve("handler"));
-            copyDirectory("../test", tempDir.resolve("test"));
-            return tempDir;
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create temp directory for Docker context", e);
-        }
     }
 
     private static void copyFile(String source, Path destination) throws Exception {

--- a/test/src/test/java/io/jeyong/test/unit/ApplicationTerminatorTest.java
+++ b/test/src/test/java/io/jeyong/test/unit/ApplicationTerminatorTest.java
@@ -4,6 +4,8 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.jeyong.handler.ApplicationTerminator;
+import java.io.File;
+import java.nio.file.Files;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import sun.misc.SignalHandler;
@@ -12,12 +14,38 @@ import sun.misc.SignalHandler;
 public class ApplicationTerminatorTest {
 
     @Test
+    @DisplayName("FileUtils.writeToFile should create a file with correct content")
+    void testFileCreationAndContent() throws Exception {
+        // given
+        File tempFile = Files.createTempFile("termination-", ".txt").toFile();
+        String terminationMessagePath = tempFile.getAbsolutePath();
+        String expectedMessage = "Test termination message";
+
+        ApplicationTerminator terminator = new ApplicationTerminator(terminationMessagePath, expectedMessage) {
+
+            @Override
+            protected int getExitCode() {
+                return 0;
+            }
+        };
+
+        // when
+        catchSystemExit(() -> terminator.handleTermination().handle(null));
+
+        // then
+        assertThat(Files.readString(tempFile.toPath())).isEqualTo(expectedMessage);
+
+        // Clean up
+        Files.deleteIfExists(tempFile.toPath());
+    }
+
+    @Test
     @DisplayName("System.exit should be called with the expected exit code")
     void testHandleTerminationCallsSystemExit() throws Exception {
         // given
         int expectedExitCode = 0;
-        ApplicationTerminator terminator = new ApplicationTerminator() {
-            
+        ApplicationTerminator terminator = new ApplicationTerminator(null, null) {
+
             @Override
             protected int getExitCode() {
                 return expectedExitCode;

--- a/test/src/test/java/io/jeyong/test/unit/SignalHandlerRegistrarTest.java
+++ b/test/src/test/java/io/jeyong/test/unit/SignalHandlerRegistrarTest.java
@@ -19,7 +19,7 @@ public class SignalHandlerRegistrarTest {
         String signalType = "TERM";
         int exitCode = 0;
         SignalHandler expectedHandler = signal -> System.exit(exitCode);
-        ApplicationTerminator terminator = new ApplicationTerminator() {
+        ApplicationTerminator terminator = new ApplicationTerminator(null, null) {
 
             @Override
             public SignalHandler handleTermination() {

--- a/test/src/test/java/io/jeyong/test/unit/SigtermHandlerPropertiesTest.java
+++ b/test/src/test/java/io/jeyong/test/unit/SigtermHandlerPropertiesTest.java
@@ -20,7 +20,9 @@ class SigtermHandlerPropertiesTest {
             classes = TestApplication.class,
             properties = {
                     "kubernetes.sigterm-handler.enabled=true",
-                    "kubernetes.sigterm-handler.exit-code=1000"
+                    "kubernetes.sigterm-handler.exit-code=1000",
+                    "kubernetes.sigterm-handler.termination-message-path=/termination-message.message",
+                    "kubernetes.sigterm-handler.termination-message=Test termination message"
             }
     )
     @DisplayName("handler enabled")
@@ -33,8 +35,8 @@ class SigtermHandlerPropertiesTest {
         private SigtermHandlerProperties sigtermHandlerProperties;
 
         @Test
-        @DisplayName("Register Configuration with the configured exit code")
-        void registerConfiguration() {
+        @DisplayName("Register Configuration with the configured properties")
+        void testRegisterConfiguration() {
             // given & when
             boolean beanExists = applicationContext.containsBeanDefinition(
                     "io.jeyong.handler.SigtermHandlerConfiguration");
@@ -43,6 +45,10 @@ class SigtermHandlerPropertiesTest {
             assertSoftly(softly -> {
                 softly.assertThat(beanExists).isTrue();
                 softly.assertThat(sigtermHandlerProperties.getExitCode()).isEqualTo(1000);
+                softly.assertThat(sigtermHandlerProperties.getTerminationMessagePath())
+                        .isEqualTo("/termination-message.message");
+                softly.assertThat(sigtermHandlerProperties.getTerminationMessage())
+                        .isEqualTo("Test termination message");
             });
         }
     }
@@ -62,7 +68,7 @@ class SigtermHandlerPropertiesTest {
 
         @Test
         @DisplayName("Does not register Configuration")
-        void doesNotRegisterConfiguration() {
+        void testDoesNotRegisterConfiguration() {
             // given & when
             boolean beanExists = applicationContext.containsBeanDefinition(
                     "io.jeyong.handler.SigtermHandlerConfiguration");

--- a/test/src/test/java/io/jeyong/test/unit/SigtermHandlerPropertiesTest.java
+++ b/test/src/test/java/io/jeyong/test/unit/SigtermHandlerPropertiesTest.java
@@ -15,14 +15,18 @@ import org.springframework.context.ApplicationContext;
 @DisplayName("SigtermHandlerProperties Unit Test")
 class SigtermHandlerPropertiesTest {
 
+    private static final int EXPECTED_EXIT_CODE = 10;
+    private static final String TERMINATION_MESSAGE_PATH = "/termination-message.message";
+    private static final String TERMINATION_MESSAGE = "Test termination message";
+
     @Nested
     @SpringBootTest(
             classes = TestApplication.class,
             properties = {
                     "kubernetes.sigterm-handler.enabled=true",
-                    "kubernetes.sigterm-handler.exit-code=1000",
-                    "kubernetes.sigterm-handler.termination-message-path=/termination-message.message",
-                    "kubernetes.sigterm-handler.termination-message=Test termination message"
+                    "kubernetes.sigterm-handler.exit-code=" + EXPECTED_EXIT_CODE,
+                    "kubernetes.sigterm-handler.termination-message-path=" + TERMINATION_MESSAGE_PATH,
+                    "kubernetes.sigterm-handler.termination-message=" + TERMINATION_MESSAGE,
             }
     )
     @DisplayName("handler enabled")
@@ -32,7 +36,7 @@ class SigtermHandlerPropertiesTest {
         private ApplicationContext applicationContext;
 
         @Autowired
-        private SigtermHandlerProperties sigtermHandlerProperties;
+        private SigtermHandlerProperties properties;
 
         @Test
         @DisplayName("Register Configuration with the configured properties")
@@ -44,11 +48,9 @@ class SigtermHandlerPropertiesTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(beanExists).isTrue();
-                softly.assertThat(sigtermHandlerProperties.getExitCode()).isEqualTo(1000);
-                softly.assertThat(sigtermHandlerProperties.getTerminationMessagePath())
-                        .isEqualTo("/termination-message.message");
-                softly.assertThat(sigtermHandlerProperties.getTerminationMessage())
-                        .isEqualTo("Test termination message");
+                softly.assertThat(properties.getExitCode()).isEqualTo(EXPECTED_EXIT_CODE);
+                softly.assertThat(properties.getTerminationMessagePath()).isEqualTo(TERMINATION_MESSAGE_PATH);
+                softly.assertThat(properties.getTerminationMessage()).isEqualTo(TERMINATION_MESSAGE);
             });
         }
     }

--- a/test/src/test/java/io/jeyong/test/unit/SigtermHandlerPropertiesTest.java
+++ b/test/src/test/java/io/jeyong/test/unit/SigtermHandlerPropertiesTest.java
@@ -19,8 +19,8 @@ class SigtermHandlerPropertiesTest {
     @SpringBootTest(
             classes = TestApplication.class,
             properties = {
-                    "kubernetes.handler.enabled=true",
-                    "kubernetes.handler.exit-code=1000"
+                    "kubernetes.sigterm-handler.enabled=true",
+                    "kubernetes.sigterm-handler.exit-code=1000"
             }
     )
     @DisplayName("handler enabled")
@@ -51,7 +51,7 @@ class SigtermHandlerPropertiesTest {
     @SpringBootTest(
             classes = TestApplication.class,
             properties = {
-                    "kubernetes.handler.enabled=false",
+                    "kubernetes.sigterm-handler.enabled=false",
             }
     )
     @DisplayName("handler disabled")


### PR DESCRIPTION
### ⭐ New Features
- **종료 메시지 기록 기능 추가**  
  - 애플리케이션이 SIGTERM 신호를 수신했을 때, 지정된 경로에 종료 메시지를 기록하도록 구현했습니다.  
  - 이를 통해 SIGTERM 신호 수신 이후 Pod의 종료 상태와 원인을 기록하여 쿠버네티스 환경에서 쉽게 파악할 수 있습니다.  
  - 종료 메시지는 아래와 같은 설정을 통해 경로와 내용을 정의할 수 있습니다.
    ```
    kubernetes:
      sigterm-handler:
        enabled: true                                # 핸들러 활성화 여부 (기본값: true)
        exit-code: 0                                # 종료 코드 설정 (기본값: 0)
        termination-message-path: /dev/termination-log  # 종료 메시지가 기록될 경로 (기본값: 설정되지 않음)
        termination-message: SIGTERM signal received...  # 종료 메시지 내용 (기본값: SIGTERM signal received. Application has been terminated successfully.)
    ```  
  - 애플리케이션 종료 후, 쿠버네티스에서 `kubectl get pod`과 같은 명령어를 통해 아래와 같은 Pod 종료 메시지를 확인할 수 있습니다.
    ```
    state:
      terminated:
        containerID: containerd://7935f0bcfd27b2d01f900029746261e0cdad8bcdbd5a7
        exitCode: 0
        finishedAt: "2024-11-29T20:22:26Z"
        message: SIGTERM signal received. Application has been terminated successfully.
        reason: Completed
        startedAt: "2024-11-29T20:20:42Z"
    ```  
  - 참고: 쿠버네티스에서 `terminationMessagePath`의 기본값은 `/dev/termination-log`입니다. 이를 커스텀하여 원하는 파일 경로에 종료 메시지를 기록할 수 있습니다.

### 🔧 Refactoring
- **설정 키 Prefix 변경**  
  - 기존 `kubernetes.handler`에서 `kubernetes.sigterm-handler`로 설정 키 Prefix가 변경되었습니다.  
  - 설정 파일에서 새로운 Prefix를 사용해 핸들러 관련 설정을 관리할 수 있습니다.
  
### 🔍 Test Enhancements
- **종료 메시지 경로 및 내용 검증 테스트 추가**  
  - 애플리케이션 종료 시 설정된 경로에 올바른 종료 메시지가 기록되는지 검증하는 테스트를 추가했습니다.  
  - 컨테이너 내부에서 종료 메시지가 기록된 파일의 내용을 읽어 검증하도록 구현했습니다.  
 
### ❤️ Contributors
- **[@joon6093](https://github.com/joon6093)**  

  이번 릴리스에 기여해주신 모든 분들께 감사드립니다!  
