### PR TITLE
Release v1.3.0

### DIFF
--- a/handler/src/main/java/io/jeyong/handler/ApplicationTerminator.java
+++ b/handler/src/main/java/io/jeyong/handler/ApplicationTerminator.java
@@ -18,10 +18,14 @@ public abstract class ApplicationTerminator {
 
     public SignalHandler handleTermination() {
         return signal -> {
-            logger.info("Received SIGTERM signal. Initiating termination handler.");
+            logTerminationSignal(signal.getName());
             FileUtils.writeToFile(terminationMessagePath, terminationMessage);
             System.exit(getExitCode());
         };
+    }
+
+    private void logTerminationSignal(final String signalName) {
+        logger.info("Received {} signal. Initiating termination handler.", signalName);
     }
 
     protected abstract int getExitCode();

--- a/handler/src/main/java/io/jeyong/handler/FileUtils.java
+++ b/handler/src/main/java/io/jeyong/handler/FileUtils.java
@@ -7,7 +7,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FileUtils {
+public final class FileUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
 

--- a/handler/src/main/java/io/jeyong/handler/SignalHandlerRegistrar.java
+++ b/handler/src/main/java/io/jeyong/handler/SignalHandlerRegistrar.java
@@ -1,6 +1,7 @@
 package io.jeyong.handler;
 
-import jakarta.annotation.PostConstruct;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import sun.misc.Signal;
 
 public final class SignalHandlerRegistrar {
@@ -13,7 +14,7 @@ public final class SignalHandlerRegistrar {
         this.signalType = signalType;
     }
 
-    @PostConstruct
+    @EventListener(ContextRefreshedEvent.class)
     public void registerHandler() {
         Signal.handle(new Signal(signalType), applicationTerminator.handleTermination());
     }

--- a/handler/src/main/java/io/jeyong/handler/SignalHandlerRegistrar.java
+++ b/handler/src/main/java/io/jeyong/handler/SignalHandlerRegistrar.java
@@ -3,7 +3,7 @@ package io.jeyong.handler;
 import jakarta.annotation.PostConstruct;
 import sun.misc.Signal;
 
-public class SignalHandlerRegistrar {
+public final class SignalHandlerRegistrar {
 
     private final ApplicationTerminator applicationTerminator;
     private final String signalType;

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -51,7 +51,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 // @formatter:on
 @ConfigurationProperties(prefix = "kubernetes.sigterm-handler")
-public class SigtermHandlerProperties {
+public final class SigtermHandlerProperties {
 
     private boolean enabled = true;
     private int exitCode = 0;

--- a/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
+++ b/handler/src/main/java/io/jeyong/handler/SigtermHandlerProperties.java
@@ -53,6 +53,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "kubernetes.sigterm-handler")
 public final class SigtermHandlerProperties {
 
+    private static final int MIN_EXIT_CODE = 0;
+    private static final int MAX_EXIT_CODE = 255;
+
     private boolean enabled = true;
     private int exitCode = 0;
     private String terminationMessagePath;
@@ -71,6 +74,7 @@ public final class SigtermHandlerProperties {
     }
 
     public void setExitCode(final int exitCode) {
+        validateExitCode(exitCode);
         this.exitCode = exitCode;
     }
 
@@ -88,5 +92,19 @@ public final class SigtermHandlerProperties {
 
     public void setTerminationMessage(final String terminationMessage) {
         this.terminationMessage = terminationMessage;
+    }
+
+    /**
+     * Validates the exit code to ensure it adheres to the POSIX standard.
+     *
+     * @param exitCode the exit code to validate
+     * @throws IllegalArgumentException if the exit code is outside the valid range
+     */
+    private void validateExitCode(final int exitCode) {
+        if (exitCode < MIN_EXIT_CODE || exitCode > MAX_EXIT_CODE) {
+            throw new IllegalArgumentException(
+                    String.format("Exit code must be between %d and %d (inclusive) as per POSIX standard.",
+                            MIN_EXIT_CODE, MAX_EXIT_CODE));
+        }
     }
 }

--- a/handler/src/main/java/io/jeyong/handler/SpringContextTerminator.java
+++ b/handler/src/main/java/io/jeyong/handler/SpringContextTerminator.java
@@ -3,7 +3,7 @@ package io.jeyong.handler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
 
-public class SpringContextTerminator extends ApplicationTerminator {
+public final class SpringContextTerminator extends ApplicationTerminator {
 
     private final ApplicationContext applicationContext;
     private final int exitCode;

--- a/test/src/test/java/io/jeyong/test/unit/ApplicationTerminatorTest.java
+++ b/test/src/test/java/io/jeyong/test/unit/ApplicationTerminatorTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.nio.file.Files;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
 @DisplayName("ApplicationTerminator Unit Test")
@@ -30,7 +31,7 @@ public class ApplicationTerminatorTest {
         };
 
         // when
-        catchSystemExit(() -> terminator.handleTermination().handle(null));
+        catchSystemExit(() -> terminator.handleTermination().handle(new Signal("TERM")));
 
         // then
         assertThat(Files.readString(tempFile.toPath())).isEqualTo(expectedMessage);
@@ -54,7 +55,7 @@ public class ApplicationTerminatorTest {
         SignalHandler handler = terminator.handleTermination();
 
         // when
-        int actualExitCode = catchSystemExit(() -> handler.handle(null));
+        int actualExitCode = catchSystemExit(() -> handler.handle(new Signal("TERM")));
 
         // then
         assertThat(actualExitCode).isEqualTo(expectedExitCode);


### PR DESCRIPTION
### ⭐ New Features
- **POSIX 표준에 따른 종료 코드 검증 기능 추가**
  - POSIX 표준에 따라 종료 코드를 0에서 255 사이로 설정할 수 있는 기능을 추가했습니다.
  - Docker 컨테이너의 종료 코드 또한 POSIX 표준을 따르며, 종료 코드는 0-255 사이의 값이어야 합니다. 만약 범위를 벗어난 값이 설정되면, 초과된 값만큼 0-255 범위 내에서 다시 시작됩니다.
  - 잘못된 종료 코드가 입력될 경우, 유효한 범위를 벗어났다는 예외 메시지가 출력됩니다.

### 🔧 Refactoring
- **Spring Application Context Events를 활용한 핸들러 초기화**
  - 기존에 사용하던 `@PostConstruct`는 실행 시점을 명확히 파악하기 어렵다는 단점이 있었습니다. 이를 해결하기 위해 Spring Application Context Events 중 하나인 `ContextRefreshedEvent`를 사용하여 핸들러 초기화 로직을 구현했습니다.
  - 이를 통해 컨텍스트 초기화가 완료되는 정확한 시점에 핸들러가 안정적으로 등록되도록 개선했습니다.

### ❤️ Contributors
- **[@joon6093](https://github.com/joon6093)**

  이번 릴리스에 기여해주신 모든 분들께 감사드립니다!
